### PR TITLE
002_paper_FGR_2024: Add JN for Figure S1

### DIFF
--- a/002_paper_FGR_2024/Figure_S1/FGR_FigS1_epidist.ipynb
+++ b/002_paper_FGR_2024/Figure_S1/FGR_FigS1_epidist.ipynb
@@ -65,7 +65,15 @@
    "id": "b3928785-64a0-4e85-b460-13cc6e93e721",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Resolutions\n",
+    "grid_dpi = 360  # Input grid\n",
+    "png_dpi = 360  # Output PNG\n",
+    "jn_dpi = 100  # Display in this Jupyter notebook\n",
+    "\n",
+    "# Name of output figure\n",
+    "map_name = \"02_out_maps/FGR_2024_GJI_FigS1_epidist\""
+   ]
   },
   {
    "cell_type": "markdown",
@@ -104,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add Jupyter notebook to reproduce **Figure S1** of _Fröhlich et al. (2024)_, see https://doi.org/10.1093/gji/ggae245.