### PR TITLE
006_tomographies_databases: Update references to SWS DBs

### DIFF
--- a/006_tomographies_databases/01_db_sws/map_db_sws_spatial_distribution.py
+++ b/006_tomographies_databases/01_db_sws/map_db_sws_spatial_distribution.py
@@ -1,8 +1,18 @@
 # #############################################################################
 # Shear wave splitting database
-# Barruol, G., Wuestefeld, A., & Bokelmann, G. (2009). SKS-Splitting-database.
-# Université de Montpellier, Laboratoire Géosciences.
-# https://doi.org/10.18715/sks_splitting_database
+#
+# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009), Identifying
+# global seismic anisotropy patterns by correlating shear-wave splitting and
+# surface-wave data, Physics of the Earth and Planetary Interiors, 176(3–4),
+# 198-212, https://doi.org/10.1016/j.pepi.2009.05.006, last access 2024/09/08.
+#
+# Shear wave splitting data is available at http://ds.iris.edu/ds/products/sws-dbs/
+# - SWS-DB: The Géosciences Montpellier SplitLab Shear-Wave Splitting Database
+#   http://ds.iris.edu/ds/products/sws-db/, last access 2024/09/08
+#   https://doi.org/10.18715/sks_splitting_database, outdated
+#   http://splitting.gm.univ-montp2.fr/, outdated
+# - SWS-DB-MST: The Missouri S&T western and central United States shear-wave splitting database
+#   http://ds.iris.edu/ds/products/sws-db-mst/, last access 2024/09/08
 #
 # Spatial distribution of splits (i.e. nulls are not considered)
 # -----------------------------------------------------------------------------

--- a/006_tomographies_databases/01_db_sws/map_db_sws_spatial_distribution.py
+++ b/006_tomographies_databases/01_db_sws/map_db_sws_spatial_distribution.py
@@ -1,9 +1,9 @@
 # #############################################################################
 # Shear wave splitting database
 #
-# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009), Identifying
+# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009). Identifying
 # global seismic anisotropy patterns by correlating shear-wave splitting and
-# surface-wave data, Physics of the Earth and Planetary Interiors, 176(3–4),
+# surface-wave data. Physics of the Earth and Planetary Interiors, 176(3–4),
 # 198-212, https://doi.org/10.1016/j.pepi.2009.05.006, last access 2024/09/08.
 #
 # Shear wave splitting data is available at http://ds.iris.edu/ds/products/sws-dbs/

--- a/006_tomographies_databases/01_db_sws/map_db_sws_splitting_parameters.py
+++ b/006_tomographies_databases/01_db_sws/map_db_sws_splitting_parameters.py
@@ -1,8 +1,18 @@
 # #############################################################################
 # Shear wave splitting database
-# Barruol, G., Wuestefeld, A., & Bokelmann, G. (2009). SKS-Splitting-database.
-# Université de Montpellier, Laboratoire Géosciences.
-# https://doi.org/10.18715/sks_splitting_database
+#
+# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009), Identifying
+# global seismic anisotropy patterns by correlating shear-wave splitting and
+# surface-wave data, Physics of the Earth and Planetary Interiors, 176(3–4),
+# 198-212, https://doi.org/10.1016/j.pepi.2009.05.006, last access 2024/09/08.
+#
+# Shear wave splitting data is available at http://ds.iris.edu/ds/products/sws-dbs/
+# - SWS-DB: The Géosciences Montpellier SplitLab Shear-Wave Splitting Database
+#   http://ds.iris.edu/ds/products/sws-db/, last access 2024/09/08
+#   https://doi.org/10.18715/sks_splitting_database, outdated
+#   http://splitting.gm.univ-montp2.fr/, outdated
+# - SWS-DB-MST: The Missouri S&T western and central United States shear-wave splitting database
+#   http://ds.iris.edu/ds/products/sws-db-mst/, last access 2024/09/08
 #
 # Splitting parameters of splits as orientated and color-coded (fast
 # polarization direction phi) length-scaled (delay time dt) bars

--- a/006_tomographies_databases/01_db_sws/map_db_sws_splitting_parameters.py
+++ b/006_tomographies_databases/01_db_sws/map_db_sws_splitting_parameters.py
@@ -1,9 +1,9 @@
 # #############################################################################
 # Shear wave splitting database
 #
-# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009), Identifying
+# Wüstefeld A., Bokelmann G., Barruol G., Montagner J.-P., (2009). Identifying
 # global seismic anisotropy patterns by correlating shear-wave splitting and
-# surface-wave data, Physics of the Earth and Planetary Interiors, 176(3–4),
+# surface-wave data. Physics of the Earth and Planetary Interiors, 176(3–4),
 # 198-212, https://doi.org/10.1016/j.pepi.2009.05.006, last access 2024/09/08.
 #
 # Shear wave splitting data is available at http://ds.iris.edu/ds/products/sws-dbs/

--- a/006_tomographies_databases/README.md
+++ b/006_tomographies_databases/README.md
@@ -4,7 +4,7 @@
 
 _Recommended versions_: PyGMT v0.11.0 / v0.12.0, GMT 6.4.0 / 6.5.0
 
-- **[01_db_sws](https://github.com/yvonnefroehlich/gmt-pygmt-plotting/tree/main/006_tomographies_databases/01_db_sws)**: `Shear wave splitting database` by [Barruol et al. 2009](https://doi.org/10.18715/sks_splitting_database), [Wüstefeld et al. 2009](https://doi.org/10.1016/j.pepi.2009.05.006)
+- **[01_db_sws](https://github.com/yvonnefroehlich/gmt-pygmt-plotting/tree/main/006_tomographies_databases/01_db_sws)**: `Shear wave splitting database` by [Wüstefeld et al. 2009](https://doi.org/10.1016/j.pepi.2009.05.006)
 - **[02_db_deepaniso](https://github.com/yvonnefroehlich/gmt-pygmt-plotting/tree/main/006_tomographies_databases/02_db_deepaniso)**: `Deep Mantel Anisotropy database` by [Wolf et al. 2023](https://doi.org/10.1029/2023GC011070) | _See also_: [Deep_Mantle_Anisotropy_Database](https://github.com/wolfjonathan/Deep_Mantle_Anisotropy_Database) by [Jonathan Wolf](https://github.com/wolfjonathan)
 - **[03_tomo_cluster_votemap](https://github.com/yvonnefroehlich/gmt-pygmt-plotting/tree/main/006_tomographies_databases/03_tomo_cluster_votemap)**: `Cluster analysis` by [Lekic et al. 2012](https://doi.org/10.1029/2010JB007631), `Votemap analysis` by [Shephard et al. 2017](https://doi.org/10.1038/s41598-017-11039-w)
 


### PR DESCRIPTION
The websites
- https://doi.org/10.18715/sks_splitting_database
- http://splitting.gm.univ-montp2.fr/

are not any available and updated to
- https://doi.org/10.1016/j.pepi.2009.05.006
- http://ds.iris.edu/ds/products/sws-db/