### PR TITLE
Use German OSM provider in Figure.tilemap to avoid blocking of tiles 

### DIFF
--- a/011_agu_FTLJG_2024/FTLJG_agu24_u12b05_pygmt_contextily.py
+++ b/011_agu_FTLJG_2024/FTLJG_agu24_u12b05_pygmt_contextily.py
@@ -12,6 +12,9 @@
 # -----------------------------------------------------------------------------
 # History
 # - Created: 2024/11/30
+# - Updated: 2026/08/12 - Fix blocking of openstreetmap tiles
+#            https://github.com/GenericMappingTools/pygmt/issues/4815
+#            https://github.com/GenericMappingTools/pygmt/pull/4816
 # -----------------------------------------------------------------------------
 # Versions
 # - PyGMT v0.13.0 -> https://www.pygmt.org/v0.13.0/ | https://www.pygmt.org/
@@ -41,7 +44,8 @@ fig.tilemap(
     region=[-77.2, -76.7, 38.7, 39],
     projection="M10c",
     zoom=10,
-    source="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    # source="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    source="https://tile.openstreetmap.de/{z}/{x}/{y}.png",
     frame=True,
 )
 fig.show()


### PR DESCRIPTION
Recent blocking of OSM tiles (~ up on August 10th 2026) downloaded and ploted via `Figure.tilemap`.

xref

- https://github.com/GenericMappingTools/pygmt/issues/4815
- https://github.com/GenericMappingTools/pygmt/pull/4816

Background

- https://wiki.openstreetmap.org/wiki/Blocked_tiles
- https://wiki.openstreetmap.org/wiki/Referer

Potentially affected

- 004_earthquakes_eruptions: 06_japan_earthquake_BFO.py -> OK
- 004_earthquakes_eruptions: 07_taiwan_earthquake_BFO.py -> OK 
- 011_agu_FTLJG_2024: FTLJG_agu24_u12b05_pygmt_contextily.py -> Use German OSM provider